### PR TITLE
Add basic ConflictManager test

### DIFF
--- a/chat_managers.py
+++ b/chat_managers.py
@@ -6,13 +6,16 @@ from agents import chat_agent
 from models import Runner
 
 class ConflictThread:
-    def __init__(self, topic: str, question: str, round_started: int):
+    def __init__(self, topic: str, question: str, initiator: str, target: str, round_started: int):
         self.topic = topic
         self.question = question
         self.sides = defaultdict(set)
         self.round_started = round_started
         self.resolved = False
         self.history = []
+        # Automatically add the initiating parties to their respective sides
+        self.add_to_side(initiator, "A")
+        self.add_to_side(target, "B")
 
     def add_to_side(self, person: str, side: str):
         if person not in self.sides[side]:
@@ -62,8 +65,6 @@ class ConflictManager:
             print(f"🚫 Конфликт слишком похож на уже активный: {existing.question}")
             return None
         new_conflict = ConflictThread(topic, question, initiator, target, round_started)
-        new_conflict.add_to_side(initiator, "A")
-        new_conflict.add_to_side(target, "B")
         self.conflicts.append(new_conflict)
         print(f"🔥 Новый конфликт: {topic} между {initiator} и {target}")
         return new_conflict

--- a/tests/test_conflict_manager.py
+++ b/tests/test_conflict_manager.py
@@ -1,0 +1,52 @@
+import types
+import sys
+import asyncio
+import pytest
+
+# Stub openai module before importing project modules
+openai_stub = types.ModuleType("openai")
+class OpenAIError(Exception):
+    pass
+class OpenAI:
+    def __init__(self, api_key=None):
+        pass
+class AsyncOpenAI(OpenAI):
+    pass
+openai_stub.OpenAI = OpenAI
+openai_stub.AsyncOpenAI = AsyncOpenAI
+openai_stub.OpenAIError = OpenAIError
+sys.modules.setdefault("openai", openai_stub)
+
+# Stub requests module to avoid dependency during import
+requests_stub = types.ModuleType("requests")
+def _dummy_post(*args, **kwargs):
+    class Resp:
+        status_code = 200
+        text = ""
+        def json(self):
+            return {}
+    return Resp()
+requests_stub.post = _dummy_post
+sys.modules.setdefault("requests", requests_stub)
+
+import chat_managers
+
+# Patch llm_conflict_similarity to avoid network calls
+async def _fake_similarity(a, b):
+    return 0.0
+chat_managers.llm_conflict_similarity = _fake_similarity
+
+from chat_managers import ConflictManager, ConflictThread
+
+def test_create_conflict():
+    manager = ConflictManager()
+    thread = asyncio.run(manager.create_conflict(
+        "Test Topic",
+        "Is this a test question?",
+        "Alice",
+        "Bob",
+        0,
+    ))
+    assert isinstance(thread, ConflictThread)
+    assert "Alice" in thread.sides["A"]
+    assert "Bob" in thread.sides["B"]


### PR DESCRIPTION
## Summary
- add tests package with ConflictManager test
- stub openai/requests for offline testing
- fix ConflictThread initializer to match create_conflict usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685989992ce88323bf0c0eabef34fd7a