### PR TITLE
Improve transaction report with detailed spending insights

### DIFF
--- a/transaction_simulator/report_generator.py
+++ b/transaction_simulator/report_generator.py
@@ -1,13 +1,14 @@
 """Simple textual report generator for transaction simulation."""
 
 from typing import List
+from datetime import datetime
 
 from pathlib import Path
 import sys
 sys.path.append(str(Path(__file__).parent.parent))
 
 from models import Person
-from .transaction_models import DailyResult
+from .transaction_models import DailyResult, SimulationConfig
 from .analyzer import ImprovedSimulationAnalyzer
 
 
@@ -20,6 +21,18 @@ class ReportGenerator:
 
     def generate_detailed_report(self, daily_results: List[DailyResult]) -> str:
         summary = self.analyzer.generate_summary(daily_results)
+        analysis = self.analyzer.analyze_simulation(
+            daily_results,
+            self.person,
+            SimulationConfig(
+                target_person_id=self.person.id,
+                start_date=datetime.now(),
+                days=len(daily_results),
+            ),
+        )
+        spending = analysis.get("spending_analysis", {})
+        insights = analysis.get("insights", [])
+
         lines = [
             f"Отчёт по симуляции для {self.person.name}",
             f"Период: {summary['total_days']} дней",
@@ -33,6 +46,17 @@ class ReportGenerator:
             lines.append(
                 f"Основная категория трат: {top_category['category']} ({top_category['amount']:.0f} RUB)"
             )
+        if spending.get("by_category"):
+            lines.append("\nТоп категории трат:")
+            for category, amount in list(spending["by_category"].items())[:5]:
+                percent = spending.get("category_distribution", {}).get(category, 0)
+                lines.append(f"- {category}: {amount:.0f} RUB ({percent:.1f}%)")
+
+        if insights:
+            lines.append("\nИнсайты и рекомендации:")
+            for ins in insights:
+                lines.append(f"- {ins}")
+
         if summary.get("key_insights"):
             lines.append("\nКлючевые инсайты:")
             for ins in summary["key_insights"]:


### PR DESCRIPTION
## Summary
- retrieve spending analysis and insights using `ImprovedSimulationAnalyzer.analyze_simulation`
- display top spending categories with amounts and percentages
- include generated insights in the report text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874d77e93e08323971f01efe1459fb3